### PR TITLE
Remove `relref` from installation-configuration.md

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -61,7 +61,7 @@ $ export REDISCLOUD_SECRET_KEY=<REDISCLOUD_SECRET_KEY>
 
 ## Configuration Options
 
-Use `pulumi config set rediscloud:<option>` or pass options to the [constructor of `new rediscloud.Provider`](/registry/packages/rediscloud/api-docs/provider).
+Use `pulumi config set rediscloud:<option>` or pass options to the [constructor of `new rediscloud.Provider`](/registry/packages/rediscloud/api-docs/provider/).
 
 | Option      | Environment Variables   | Required/Optional | Description            |
 | ----------- | ----------------------- | ----------------- | ---------------------- |

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -61,7 +61,7 @@ $ export REDISCLOUD_SECRET_KEY=<REDISCLOUD_SECRET_KEY>
 
 ## Configuration Options
 
-Use `pulumi config set rediscloud:<option>` or pass options to the [constructor of `new rediscloud.Provider`]({{< relref "/registry/packages/rediscloud/api-docs/provider" >}}).
+Use `pulumi config set rediscloud:<option>` or pass options to the [constructor of `new rediscloud.Provider`](/registry/packages/rediscloud/api-docs/provider).
 
 | Option      | Environment Variables   | Required/Optional | Description            |
 | ----------- | ----------------------- | ----------------- | ---------------------- |


### PR DESCRIPTION
The Pulumi Registry package publishing process no longer makes use of `relref`. The current use of `relref` seems to block our publishing process somewhere. Removing it from your sources streamlines further releases in our Pulumi Registry.